### PR TITLE
Add SSH client for cloning private repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk --no-cache update && \
       curl \
       py-pip \
       openssl \
+      openssh \      
       bash \
       gettext \
       g++ \


### PR DESCRIPTION

By adding SSH enables pipelines to clone private repositories with terraform modules for example.